### PR TITLE
Feature/sort discussions descending

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
@@ -234,6 +235,8 @@ GEM
     minitest (5.25.5)
     net-http (0.6.0)
       uri
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -271,6 +274,7 @@ GEM
     webrick (1.9.1)
 
 PLATFORMS
+  arm64-darwin-25
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/_includes/discussions-script.html
+++ b/_includes/discussions-script.html
@@ -105,6 +105,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const discussions = await response.json();
 
             if (Array.isArray(discussions) && discussions.length > 0) {
+                discussions.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
                 renderDiscussions(discussions);
             } else {
                 throw new Error('No discussions data found');


### PR DESCRIPTION
I thought it would be useful to have discussions sorted in a manner as to have the most active discussions appear first. So I made this minor tweak to the GitHub script. 